### PR TITLE
Fix: Resolve DEV container permission errors with named volume and init chown

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -11,6 +11,20 @@ services:
     extends:
       service: frontend-dev
       file: compose-version.yml
+    volumes:
+      - ./frontend:/app
+      - frontend_node_modules:/app/node_modules
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=development
+    user: root
+    command: >
+      sh -c "
+        chown -R node:node /app/node_modules &&
+        chmod -R 755 /app/node_modules &&
+        su node -c '/bin/bash /app/script/entrypoint-dev.sh'
+      "
   db:
     image: ghcr.io/openimis/openimis-pgsql:${DB_TAG:-develop}
     environment:
@@ -56,3 +70,4 @@ volumes:
   nodes_volume:
   pip-cache:
   venv:
+  frontend_node_modules:


### PR DESCRIPTION
# Description

fix permission errors in frontend dev container by isolating "node_modules" with a named volume and enabling dev stage

## Changes

- [x] [resolve dev container permission errors with named volume and init chown](https://github.com/openimis/openimis-dev-tools/commit/5b2db269bb793c4b4ff9924d5753e19511656cda)

## Demo

```
# before: EACCES: permission denied, mkdir '/app/node_modules/@alloc'
# after : Compiled successfully! → http://localhost:3000/front/
```

## How to Test

* docker compose up -d --build