### PR TITLE
fix: update frontend and backend setup instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,14 @@ python setup-local-dev.py CoreMIS
 ### Run the Frontend locally
 ```bash
 cd frontend
+# install assembly dependancies
+npm install --legacy-peer-deps
+# normalize the openimis-dev.json file initially done for docker
+sed -i 's#file:/\./#file:../#g' openimis-dev.json
 # install all modules
-node dev_tools/entrypoint-dev.js 
+node dev_tools/entrypoint-dev.js -c ./openimis-dev.json
 # load the module in assembly
-npm run load-config -c ./openimis.json
+npm run load-config -- ./openimis.json
 # install node packages
 npm  install --include=dev --legacy-peer-deps
 # run app (need backend up or error 500)
@@ -78,10 +82,10 @@ cd backend
 pip install -r requirements.txt
 # get the requirement for all modules
 python script/modules-requirements.py ../openimis-dev.json > script/modules-requirements.txt
-# install modules requirements
-pip install -r script/modules-requirements.txt
 # to addapt the script that was initially done for docker
 sed -i 's#/\./#../#g' script/modules-requirements.txt
+# install modules requirements
+pip install -r script/modules-requirements.txt
 # to keep custom version of django-appscheduler working 
 pip install "setuptools<81"
 cd openIMIS


### PR DESCRIPTION
# Description

This pull request updates the project README to reflect the correct setup process for both frontend and backend local development environments.

The previous documentation contained inconsistencies between the documented commands and the actual behavior of the configuration scripts, particularly around the handling of `openimis.json` vs `openimis-dev.json`. These updates ensure that developers can successfully run the application locally using the generated development configuration.

***

## Changes

* [x] Updated frontend setup instructions to correctly use `openimis-dev.json`
* [x] Corrected `load-config` command usage (removed unsupported `-c` flag usage)
* [ ] Added fixes and refactors to the scripts (handled in a separate PRs)

***

## Demo

N/A – Documentation update only

***

## How to Test

1. Run the local environment setup:
   ```bash
   python setup-local-dev.py
   ```

2. Start the frontend using the updated instructions:
   ```bash
   cd frontend
   sed -i 's#file:/\./#file:../#g' openimis-dev.json
   node dev_tools/entrypoint-dev.js -c ./openimis-dev.json
   npm run load-config -- ./openimis-dev.json
   npm install --include=dev --legacy-peer-deps
   npm run start
   ```

3. Verify that:
   * The frontend runs successfully without configuration errors
   * Modules are loaded from local paths as defined in `openimis-dev.json`
   * No issues arise from incorrect config file references

